### PR TITLE
Ignore node_modules folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/


### PR DESCRIPTION
# Summary

We forgot to add a .gitignore. This adds one, that for now just ignores anything in `node_modules/`
	
## Test Plan

N/A

## Related Issues

N/A