### PR TITLE
Enhance my history page's date range selection buttons

### DIFF
--- a/frontend/src/Components/MyHistory/ModalCalendars/EndDateCalendar.tsx
+++ b/frontend/src/Components/MyHistory/ModalCalendars/EndDateCalendar.tsx
@@ -7,6 +7,7 @@ const EndDateCalendar = (props: {
   selectEndDate: Function;
   updateIsSelectingStartDate: Function;
   endDate: Date | null;
+  closeModal: Function;
 }) => {
   return (
     <>
@@ -34,9 +35,21 @@ const EndDateCalendar = (props: {
         >
           Back
         </Button>
-        <Button sx={{ bgcolor: "#C4C4C4", ml: "5px" }} disabled>
-          Next
-        </Button>
+        {/* Disable confirm button when no endDate is chosen */}
+        {props.endDate ? (
+          <Button
+            sx={{ bgcolor: "#3A71FF", color: "white", ml: "5px" }}
+            onClick={() => {
+              props.closeModal();
+            }}
+          >
+            Confirm
+          </Button>
+        ) : (
+          <Button sx={{ bgcolor: "#C4C4C4", ml: "5px" }} disabled>
+            Confirm
+          </Button>
+        )}
       </Box>
     </>
   );

--- a/frontend/src/Components/MyHistory/ModalCalendars/StartDateCalendar.tsx
+++ b/frontend/src/Components/MyHistory/ModalCalendars/StartDateCalendar.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Box, Button, Typography } from "@mui/material";
 import { DateCalendar } from "@mui/x-date-pickers";
-import dayjs from 'dayjs'; // dayjs is needed for calendar
+import dayjs from "dayjs"; // dayjs is needed for calendar
 
 const StartDateCalendar = (props: {
   selectStartDate: Function;
@@ -25,18 +25,23 @@ const StartDateCalendar = (props: {
         }}
       />
       <Box sx={{ display: "flex", justifyContent: "center", mb: 3 }}>
-        <Button sx={{ bgcolor: "#C4C4C4", mr: "5px" }} disabled>
-          Back
-        </Button>
-        <Button
-          sx={{ bgcolor: "#3A71FF", color: "white", ml: "5px" }}
-          onClick={() => {
-            // to display end date selecting calendar
-            props.updateIsSelectingStartDate(false);
-          }}
-        >
-          Next
-        </Button>
+        {props.startDate ? (
+          <Button
+            sx={{ bgcolor: "#3A71FF", color: "white", ml: "5px" }}
+            onClick={() => {
+              // Display end date selecting calendar, only if startDate is selected already.
+              props.updateIsSelectingStartDate(false);
+            }}
+          >
+            Next
+          </Button>
+        ) : (
+          // Disable next button when no start date is selected.
+          <Button
+            disabled
+            sx={{ bgcolor: "#C4C4C4", ml: "5px" }}
+          >Next</Button>
+        )}
       </Box>
     </>
   );

--- a/frontend/src/Containers/HistoryContainer.tsx
+++ b/frontend/src/Containers/HistoryContainer.tsx
@@ -84,6 +84,7 @@ const HistoryContainer = () => {
                   selectEndDate={endDateChangeHandler}
                   updateIsSelectingStartDate={updateIsSelectingStartDate}
                   endDate={endDate}
+                  closeModal={modalCloseHandler}
                 />
               )}
             </Box>


### PR DESCRIPTION
# Summary

Made the enhancement on calendar date range selection buttons in my history page as requested by Selena. Let me know if there is any stylistic enhancement anybody wants to suggest, like the confirm buttons color being different from other buttons, etc.

**Preview**
Before selecting start date:
![Screenshot 2023-05-07 at 10 39 21 PM](https://user-images.githubusercontent.com/96888460/236723021-00027254-f93d-4186-87f7-164e1d055749.png)

After selecting start date:
![Screenshot 2023-05-07 at 10 52 53 PM](https://user-images.githubusercontent.com/96888460/236723595-7cb90d5a-d27b-4bb1-adc1-e77e7956313b.png)

Before selecting end date:
![Screenshot 2023-05-07 at 10 53 03 PM](https://user-images.githubusercontent.com/96888460/236723783-c9cfc413-0bf3-4b45-b81b-475129b85692.png)

After selecting end date:
![Screenshot 2023-05-07 at 10 38 05 PM](https://user-images.githubusercontent.com/96888460/236723097-0b3215f6-1ee4-44ea-a528-0041639b5a75.png)

## Related Issues

Which issues does this PR resolve/work on?
Closes #109 