### PR TITLE
Kihyeok/my tasks page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 .DS_Store
 *.lock
+backend/build/
+frontend/build/

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,11 +3,12 @@ import Header from "./Components/Header/Header";
 import NavBar from "./Components/NavBar/NavBar";
 import RouterComponent from "./Router";
 import { Box } from "@mui/material";
+import { getCurrentUserId } from "./helper";
 import "./App.css";
 
 // Create a functional component
 export default function App() {
-  const userId = localStorage.getItem("userId");
+  const userId = getCurrentUserId();
 
   useEffect(() => {
     if (userId && window.location.pathname === "/") {

--- a/frontend/src/Components/MyTasks/AvailabilitiesCheckIn/AvailabilitiesCheckIn.tsx
+++ b/frontend/src/Components/MyTasks/AvailabilitiesCheckIn/AvailabilitiesCheckIn.tsx
@@ -1,8 +1,27 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Box, Typography } from "@mui/material";
 import { CgDanger } from "react-icons/cg";
+import { getAvailabilitiesLastUpdated } from "../../../services";
+import { getCurrentUserId } from "../../../helper";
 
 const AvailabilitiesCheckIn = () => {
+  const userId : string | null | undefined = getCurrentUserId();
+  const intUserId : number = userId ? parseInt(userId) : -1;
+  console.log("mee", userId, intUserId)
+  const [availabilityLastUpdated, setAvailabilityLastUpdated] = useState("");
+
+  useEffect(() => {
+    const getLastUpdatedDate = async () => {
+      const lastUpdatedDate = await getAvailabilitiesLastUpdated(
+        intUserId
+      );
+      console.log("lastUpdated Date is: ", lastUpdatedDate);
+      setAvailabilityLastUpdated(lastUpdatedDate);
+    };
+
+    getLastUpdatedDate();
+  }, []);
+
   return (
     <Box
       sx={{

--- a/frontend/src/Components/MyTasks/AvailabilitiesCheckIn/AvailabilitiesCheckIn.tsx
+++ b/frontend/src/Components/MyTasks/AvailabilitiesCheckIn/AvailabilitiesCheckIn.tsx
@@ -1,25 +1,37 @@
 import React, { useEffect, useState } from "react";
 import { Box, Typography } from "@mui/material";
-import { CgDanger } from "react-icons/cg";
+import { CgDanger, CgCheckO } from "react-icons/cg";
 import { getAvailabilitiesLastUpdated } from "../../../services";
 import { getCurrentUserId } from "../../../helper";
+import dayjs from "dayjs";
+import weekOfYear from "dayjs/plugin/weekOfYear";
+dayjs.extend(weekOfYear); // enable using plugin for dayjs
 
 const AvailabilitiesCheckIn = () => {
-  const userId : string | null | undefined = getCurrentUserId();
-  const intUserId : number = userId ? parseInt(userId) : -1;
-  console.log("mee", userId, intUserId)
-  const [availabilityLastUpdated, setAvailabilityLastUpdated] = useState("");
+  const [isAvailabilityUpdatedThisWeek, setIsAvailabilityUpdatedThisWeek] =
+    useState(false);
+  const userId: string | null | undefined = getCurrentUserId();
+  const intUserId: number = userId ? parseInt(userId) : -1;
+  console.log("mee", userId, intUserId);
 
   useEffect(() => {
-    const getLastUpdatedDate = async () => {
-      const lastUpdatedDate = await getAvailabilitiesLastUpdated(
+    const isAvailUpdated = async () => {
+      const availabilityLastUpdated = await getAvailabilitiesLastUpdated(
         intUserId
       );
-      console.log("lastUpdated Date is: ", lastUpdatedDate);
-      setAvailabilityLastUpdated(lastUpdatedDate);
+      console.log("lastUpdated Date is: ", availabilityLastUpdated);
+      const weekOfLastUpdatedDate = dayjs("2023-07-07").week();
+      const currentWeek = dayjs(new Date()).week()
+      console.log(
+        "this week: ",
+        currentWeek,
+        "last week: ",
+        weekOfLastUpdatedDate
+      );
+      setIsAvailabilityUpdatedThisWeek(currentWeek === weekOfLastUpdatedDate);
     };
 
-    getLastUpdatedDate();
+    isAvailUpdated();
   }, []);
 
   return (
@@ -44,28 +56,53 @@ const AvailabilitiesCheckIn = () => {
           marginLeft: 2,
         }}
       >
-        <Typography
-          sx={{
-            fontFamily: "Poppins",
-            fontWeight: 400,
-            fontSize: 10,
-            color: "#FB4B4B",
-          }}
-        >
-          Not Completed
-        </Typography>
+        {isAvailabilityUpdatedThisWeek ? (
+          <Typography
+            sx={{
+              fontFamily: "Poppins",
+              fontWeight: 400,
+              fontSize: 10,
+              color: "#85CF27",
+            }}
+          >
+            Completed
+          </Typography>
+        ) : (
+          <Typography
+            sx={{
+              fontFamily: "Poppins",
+              fontWeight: 400,
+              fontSize: 10,
+              color: "#FB4B4B",
+            }}
+          >
+            Not Completed
+          </Typography>
+        )}
         <Typography
           sx={{ fontFamily: "Poppins", fontWeight: 600, fontSize: 18 }}
         >
           Availability Check-In
         </Typography>
-        <Typography
-          sx={{ fontFamily: "Poppins", fontWeight: 400, fontSize: 12 }}
-        >
-          Mark Your Weekly Availabilities
-        </Typography>
+        {isAvailabilityUpdatedThisWeek ? (
+          <Typography
+            sx={{ fontFamily: "Poppins", fontWeight: 400, fontSize: 12 }}
+          >
+            Edit Your Weekly Availabilities
+          </Typography>
+        ) : (
+          <Typography
+            sx={{ fontFamily: "Poppins", fontWeight: 400, fontSize: 12 }}
+          >
+            Mark Your Weekly Availabilities
+          </Typography>
+        )}
       </Box>
-      <CgDanger size="45" style={{ marginRight: 20, color: "#FB4B4B" }} />
+      {isAvailabilityUpdatedThisWeek ? (
+        <CgCheckO size="45" style={{ marginTop: 10, marginRight: 20, color: "#85CF27" }} />
+      ) : (
+        <CgDanger size="45" style={{ marginTop: 10, marginRight: 20, color: "#FB4B4B" }} />
+      )}
     </Box>
   );
 };

--- a/frontend/src/Components/MyTasks/AvailabilitiesCheckIn/AvailabilitiesCheckIn.tsx
+++ b/frontend/src/Components/MyTasks/AvailabilitiesCheckIn/AvailabilitiesCheckIn.tsx
@@ -20,7 +20,7 @@ const AvailabilitiesCheckIn = () => {
         intUserId
       );
       console.log("lastUpdated Date is: ", availabilityLastUpdated);
-      const weekOfLastUpdatedDate = dayjs("2023-07-07").week();
+      const weekOfLastUpdatedDate = dayjs(availabilityLastUpdated).week();
       const currentWeek = dayjs(new Date()).week();
       console.log(
         "this week: ",

--- a/frontend/src/Components/MyTasks/AvailabilitiesCheckIn/AvailabilitiesCheckIn.tsx
+++ b/frontend/src/Components/MyTasks/AvailabilitiesCheckIn/AvailabilitiesCheckIn.tsx
@@ -21,7 +21,7 @@ const AvailabilitiesCheckIn = () => {
       );
       console.log("lastUpdated Date is: ", availabilityLastUpdated);
       const weekOfLastUpdatedDate = dayjs("2023-07-07").week();
-      const currentWeek = dayjs(new Date()).week()
+      const currentWeek = dayjs(new Date()).week();
       console.log(
         "this week: ",
         currentWeek,
@@ -99,9 +99,15 @@ const AvailabilitiesCheckIn = () => {
         )}
       </Box>
       {isAvailabilityUpdatedThisWeek ? (
-        <CgCheckO size="45" style={{ marginTop: 10, marginRight: 20, color: "#85CF27" }} />
+        <CgCheckO
+          size="45"
+          style={{ marginTop: 10, marginRight: 20, color: "#85CF27" }}
+        />
       ) : (
-        <CgDanger size="45" style={{ marginTop: 10, marginRight: 20, color: "#FB4B4B" }} />
+        <CgDanger
+          size="45"
+          style={{ marginTop: 10, marginRight: 20, color: "#FB4B4B" }}
+        />
       )}
     </Box>
   );

--- a/frontend/src/Components/MyTasks/TaskCompletionFilter.tsx
+++ b/frontend/src/Components/MyTasks/TaskCompletionFilter.tsx
@@ -13,7 +13,7 @@ enum TaskCompletionOption {
 
 const TaskCompletionFilter = (props: { updateCompletionFilter: Function }) => {
   const [taskCompletionType, setTaskCompletionType] = useState(
-    TaskCompletionOption.AllDeliveries as string
+    TaskCompletionOption.Upcoming as string // set upcoming as default option for filtering deliveries
   );
 
   const taskCompletionChangeHandler = (event: SelectChangeEvent<string>) => {

--- a/frontend/src/Containers/AvailabilitiesContainer.tsx
+++ b/frontend/src/Containers/AvailabilitiesContainer.tsx
@@ -381,6 +381,7 @@ const MarkAvailability = () => {
         editVolunteerAvailabilities(parseInt(volunteerId), avails);
         editAvailabilitiesLastUpdated(parseInt(volunteerId), date);
         setSaveSuccess(1);
+        window.location.href = "/tasks"; // redirect to my deliveries page once availability is updated.
       }
     } catch (e) {
       setSaveSuccess(2);

--- a/frontend/src/Containers/TasksContainter.tsx
+++ b/frontend/src/Containers/TasksContainter.tsx
@@ -12,7 +12,7 @@ import { useState } from "react";
 const TasksContainer = () => {
   // dateFilter and completionFilter state will be used to filter tasks. Current date is used to initialize dateFilter in its context.
   // completionFilter state will be passed down to DeliviesContainer.
-  const [completionFilter, setCompletionFilter] = useState("ALLDELIVERIES"); // set ALLDELIVERIES as default
+  const [completionFilter, setCompletionFilter] = useState("UPCOMING"); // set Upcomming as default
 
   // this function will be passed down using props
   const completionFilterUpdateHandler = (completionType: string) => {

--- a/frontend/src/services.ts
+++ b/frontend/src/services.ts
@@ -6,7 +6,7 @@ import { getCurrentUserId } from "./helper";
 
 // URL to which requests will be sent
 const API_URL = "http://localhost:3001/api";
-const VOLUNTEER_ID = getCurrentUserId(); // will need to be replaced with actual logged in volunteer's id.
+const VOLUNTEER_ID = getCurrentUserId(); // may return null, which occurs when user is not logged in but tries to access other pages.
 
 //Task services
 
@@ -27,6 +27,9 @@ export const getAllTasks = async () => {
 export const getOneVolunteerTasks = async () => {
   try {
     // Uses axios to make a get request at "http://localhost:3001/api/tasks"
+    if (!VOLUNTEER_ID) {
+      return {} // getCurrentUserId() can return null, which causes error. Do not send request to backend with null.
+    }
     const response = await axios.get(
       `${API_URL}/tasks/volunteer/${VOLUNTEER_ID}`
     );


### PR DESCRIPTION
# Summary

This PR fixes/adds the following:
1. Display different availabilities header when a user updates availabilities for the current week. The user can still edit their availabilities for the current week. Sunday to Saturday is considered to be in the same week.
     ![Screenshot 2023-07-07 at 10 49 51 PM](https://github.com/hack4impact-mcgill/MADA-v2/assets/96888460/b6229c42-4c98-4af2-851c-d1640c91d942)
Maybe users should be able to update the upcoming week's availabilities in advance? So that directors can assign tasks in advance
2.  Set "Upcoming" as the default option for filtering deliveries, as requested by MADA.
3. When a user logs in, closes the tab, opens another tab, and tries to access other pages, an error occurs. This PR fixes this behaviour.

 Test Plan:
1. Once you update the availabilities, you should be able to see the new availabilities-check-in header. You should also be redirected to my deliveries page when you click "save" when updating availabilities.
2. Try to log in, close the tab, open another tab, and try to access other pages, and see if an error occurs.

## Related Issues

Which issues does this PR resolve/work on?
Closes #